### PR TITLE
Document core API and add AGENTIC.md agent guide

### DIFF
--- a/AGENTIC.md
+++ b/AGENTIC.md
@@ -1,0 +1,118 @@
+# AGENTIC.md
+
+Guidance for AI coding agents (Claude Code and similar) working in this repository.
+
+## What this package is
+
+`TextSearch.jl` is a Julia package that turns text into vector/sparse representations
+(BOW, TF, TF-IDF, entropy-based weightings, BM25) and provides an inverted-file index
+(via [`InvertedFiles.jl`](https://github.com/sadit/InvertedFiles.jl)) for searching them.
+It is meant to be paired with [`SimilaritySearch.jl`](https://github.com/sadit/SimilaritySearch.jl).
+The package was previously named `TextModel.jl`.
+
+## Processing pipeline (mental model)
+
+Understanding the data flow makes it much easier to find where a change belongs:
+
+```
+raw text/corpus
+  → TextConfig (textconfig.jl)         preprocessing options (lowercase, diacritics, url/user/number
+                                        grouping, q-grams, n-grams, skip-grams, token transforms)
+  → normalize_text (normalize.jl)      character-level normalization
+  → tokenize (tokenize.jl)             produces a TokenizedText (list of token strings)
+  → Vocabulary (voc.jl, updatevoc.jl)  token ⇄ id mapping, occurrence/doc-frequency counters
+  → BOW / bagofwords (bow.jl)          Dict{UInt32,Int32} bag-of-words per document
+  → VectorModel (vmodel.jl, emodel.jl) local/global weighting schemes → SVEC (sparse Dict vector)
+       or
+  → BM25 (bm25.jl) + BM25InvertedFile (bm25invfile.jl, bm25invfilesearch.jl)  index + kNN search
+```
+
+`sparseconversions.jl` / `dvec.jl` bridge between the package's `Dict`-based sparse
+vectors (`BOW = Dict{UInt32,Int32}`, `SVEC = Dict{UInt32,Float32}`) and
+`SparseArrays`/`SimilaritySearch` vector types (arithmetic, norms, distances).
+
+## Source file map
+
+| File | Responsibility |
+|---|---|
+| `TextSearch.jl` | Module entry point, includes, `TextSearchBuffer` thread-local buffer pool |
+| `textconfig.jl` | `TextConfig`, `Skipgram` — tokenization/preprocessing configuration |
+| `tokentrans.jl` | `AbstractTokenTransformation` hooks (stemming, stopwords, chaining) |
+| `normalize.jl` | Character-level text normalization, emoji detection |
+| `tokenize.jl` | `TokenizedText`, `tokenize`/`tokenize_corpus`, q-grams/n-grams/skip-grams |
+| `voc.jl` | `Vocabulary` type: token↔id table, occurrence/ndocs counters |
+| `updatevoc.jl` | Merging/updating `Vocabulary` instances |
+| `approxvoc.jl` | Approximate vocabulary lookup (`QgramsLookup`) for fuzzy/OOV matching |
+| `tokcorpus.jl` | `EncodedCorpus` — corpus encoded as token-id sequences |
+| `bow.jl` | Bag-of-words construction from tokenized text |
+| `sparseconversions.jl` | Conversions between `Dict` sparse vectors and `SparseArrays` |
+| `dvec.jl` | Arithmetic/distance operations (`+`, `-`, `dot`, `norm`, centroid, Cosine/Angle) on `SVEC` |
+| `vmodel.jl` | `VectorModel`, local/global weighting schemes (TF, IDF, TP, binary), `vectorize` |
+| `emodel.jl` | Entropy-based weighting schemes (`EntropyWeighting`, `CombineWeighting`) |
+| `multi.jl` | Merging/joining `VectorModel`s (`update!`, `joinmodel`) — requires `KCenters` |
+| `bm25.jl` | `BM25` scoring struct and `bm25score`/`tokenscore` |
+| `bm25invfile.jl` | `BM25InvertedFile` — the inverted-file index built on `InvertedFiles.jl` |
+| `bm25invfilesearch.jl` | kNN search over `BM25InvertedFile` (uses `Intersections.jl`) |
+| `deprecated.jl` | Backwards-compatible shims for renamed/removed APIs |
+
+## Dev environment
+
+```julia
+# from repo root
+julia --project=. -e 'using Pkg; Pkg.instantiate()'
+```
+
+Run the test suite:
+
+```julia
+julia --project=. -e 'using Pkg; Pkg.test()'
+# or, from a REPL with the project active:
+] test
+```
+
+Individual test files live under `test/` and are included from `test/runtests.jl`:
+`tok.jl` (tokenization), `voc.jl` (vocabulary), `vec.jl` (vector models/weighting),
+`search.jl` (BM25 inverted file search).
+
+Build the docs (Documenter.jl):
+
+```julia
+julia --project=docs docs/make.jl
+```
+
+CI (`.github/workflows/ci.yml`) runs on Julia 1.10 for Ubuntu and Windows and uploads
+coverage to Codecov. `documentation.yml` builds and deploys docs on pushes/tags to `main`.
+
+## Conventions and gotchas
+
+- **Julia version floor is 1.10** (`Project.toml` `[compat] julia = "^1.10"`). Don't use
+  syntax/stdlib features newer than that.
+- **`Aqua.jl` runs in the test suite** (`test/runtests.jl`): ambiguity and type-piracy
+  checks (`Aqua.test_ambiguities`, `Aqua.test_piracies`). If you add methods that
+  extend `Base`/`LinearAlgebra`/`SparseArrays` functions on non-owned types, add them to
+  the `treat_as_own` list in `runtests.jl` if they're intentional, otherwise avoid the
+  piracy.
+- **Sparse vectors are plain `Dict`s**, not `SparseVector`: `BOW = Dict{UInt32,Int32}`,
+  `SVEC = Dict{UInt32,Float32}` (defined in `TextSearch.jl`). Arithmetic/distance
+  operators for them live in `dvec.jl` — extend there, not ad hoc elsewhere.
+- **Buffer pooling**: `TextSearchBuffer`/`TEXT_SEARCH_CACHES` in `TextSearch.jl` is a
+  channel-based per-thread buffer pool used to avoid allocations during tokenization;
+  use `textbuffer(f)` rather than allocating new buffers in hot paths.
+- **Struct immutability**: most core types (`TextConfig`, `Vocabulary`, `BM25`, …) are
+  immutable `struct`s with explicit copy-constructors (e.g. `TextConfig(c::TextConfig; kwargs...)`)
+  for "update a field" patterns — follow that pattern instead of adding mutability.
+- **Custom `Base.show` methods** exist for most structs with a `prefix`/`indent` keyword
+  convention for nested pretty-printing — match this style for new types.
+- **Docstrings** use standard Julia docstring format with a signature block followed by
+  a description and `- field: description` bullet lists; keep new public API documented
+  the same way and cross-reference with `` [`Type`](@ref) ``.
+- This package depends on unreleased/companion packages from the same author
+  (`InvertedFiles.jl`, `Intersections.jl`, `SimilaritySearch.jl`) — check their APIs
+  when a search/index-related change looks like it needs upstream changes too.
+
+## Where to look for more context
+
+- `README.md` — install/usage overview, links to Pluto notebook examples in `examples/`.
+- `docs/src/index.md`, `docs/src/api.md` — narrative docs and API reference source.
+- `examples/invindex.jl`, `examples/searchgraph.jl` — Pluto notebooks demonstrating
+  end-to-end usage.

--- a/src/TextSearch.jl
+++ b/src/TextSearch.jl
@@ -14,7 +14,22 @@ using Polyester, ProgressMeter
 
 include("dvec.jl")
 
+"""
+    BOW = Dict{UInt32,Int32}
+
+A bag of words: a sparse `token id => occurrence count` mapping for a single document,
+as produced by [`bagofwords`](@ref)/[`bagofwords!`](@ref).
+"""
 const BOW = Dict{UInt32,Int32}
+
+"""
+    SVEC = Dict{UInt32,Float32}
+
+A weighted sparse vector: a `token id => weight` mapping, as produced by
+[`vectorize`](@ref)/[`vectorize!`](@ref). Arithmetic (`+`, `-`, `*`, `/`), norms, and
+distances for `SVEC`/`BOW`-like `Dict`s are defined in `dvec.jl` (see [`normalize!`](@ref),
+[`dot`](@ref), [`norm`](@ref), [`centroid`](@ref)).
+"""
 const SVEC = Dict{UInt32,Float32}
 
 export SVEC, BOW

--- a/src/TextSearch.jl
+++ b/src/TextSearch.jl
@@ -19,6 +19,13 @@ include("dvec.jl")
 
 A bag of words: a sparse `token id => occurrence count` mapping for a single document,
 as produced by [`bagofwords`](@ref)/[`bagofwords!`](@ref).
+
+# Example
+
+```julia
+julia> BOW(0x00000001 => 2, 0x00000002 => 1)
+Dict{UInt32, Int32}(0x00000002 => 1, 0x00000001 => 2)
+```
 """
 const BOW = Dict{UInt32,Int32}
 
@@ -29,6 +36,13 @@ A weighted sparse vector: a `token id => weight` mapping, as produced by
 [`vectorize`](@ref)/[`vectorize!`](@ref). Arithmetic (`+`, `-`, `*`, `/`), norms, and
 distances for `SVEC`/`BOW`-like `Dict`s are defined in `dvec.jl` (see [`normalize!`](@ref),
 [`dot`](@ref), [`norm`](@ref), [`centroid`](@ref)).
+
+# Example
+
+```julia
+julia> SVEC(0x00000001 => 0.5f0)
+Dict{UInt32, Float32}(0x00000001 => 0.5)
+```
 """
 const SVEC = Dict{UInt32,Float32}
 

--- a/src/bm25.jl
+++ b/src/bm25.jl
@@ -16,6 +16,19 @@ uses a `BM25` internally to answer top-k queries efficiently.
 BM25 `k1`/`b` hyperparameters and the corpus' average document length, precomputed for
 faster scoring; `δ` is the BM25+ lower-bound correction term; `trainsize` is the number
 of documents the corpus statistics were computed from.
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> bm25 = BM25(voc);
+
+julia> bm25.trainsize
+3
+```
 """
 struct BM25
     #k1::Float32
@@ -48,6 +61,15 @@ end
 Creates a [`BM25`](@ref) scorer for a corpus of `trainsize` documents with average
 document length `avgdoclen`. `k1` controls term-frequency saturation, `b` controls
 document-length normalization, and `δ` is the BM25+ lower-bound correction.
+
+# Example
+
+```julia
+julia> bm25 = BM25(3, 3.5);
+
+julia> bm25.trainsize
+3
+```
 """
 function BM25(trainsize::Integer, avgdoclen::AbstractFloat; k1=1.2f0, b=0.75f0, δ=1f0)
     BM25( #k1, b,
@@ -64,6 +86,17 @@ end
 
 Creates a [`BM25`](@ref) scorer using the training size and average document length
 already computed in `voc` (see [`trainsize`](@ref) and [`avgdoclen`](@ref)).
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> BM25(voc).trainsize
+3
+```
 """
 BM25(voc::Vocabulary; k1=1.2f0, b=0.75f0, δ=1f0) = BM25(trainsize(voc), avgdoclen(voc); k1, b, δ)
 
@@ -72,6 +105,19 @@ BM25(voc::Vocabulary; k1=1.2f0, b=0.75f0, δ=1f0) = BM25(trainsize(voc), avgdocl
 
 Computes the BM25 relevance score of `doc` (a bag of words) for `query` (a bag of words),
 summing [`tokenscore`](@ref) over every query token present in `doc`. Higher is more relevant.
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> bm25 = BM25(voc);
+
+julia> bm25score(bm25, voc, bagofwords(voc, "hello"), bagofwords(voc, "hello world"))
+0.96917987f0
+```
 """
 function bm25score(bm25::BM25, voc::Vocabulary, query::Dict, doc::Dict)::Float32
     s = 0f0
@@ -94,6 +140,17 @@ Computes the BM25 contribution of a single token to a document's score, given th
 number of documents containing the token (`toknumdocs`, i.e. its document frequency),
 the document's length in tokens (`doclen`), and the token's frequency in the document
 (`tokfreqindoc`). Used internally by [`bm25score`](@ref) and [`BM25InvertedFile`](@ref) search.
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> tokenscore(BM25(voc), 2, 3, 1)
+0.8908208f0
+```
 """
 function tokenscore(bm25::BM25, toknumdocs, doclen, tokfreqindoc)
     idf = log(1f0 + (bm25.trainsize - toknumdocs + 0.5f0) / (toknumdocs + 0.5f0))

--- a/src/bm25.jl
+++ b/src/bm25.jl
@@ -1,6 +1,22 @@
 # This file is a part of TextSearch.jl
 export BM25, bm25score, tokenscore
 
+"""
+    BM25
+
+Precomputed coefficients for the Okapi BM25 (BM25+) scoring function, used to rank
+documents against a query given per-token document frequencies and document lengths.
+Build one with [`BM25(voc)`](@ref BM25) or [`BM25(trainsize, avgdoclen)`](@ref BM25);
+score individual (token-frequency, document-length) pairs with [`tokenscore`](@ref), or
+whole query/document bags of words with [`bm25score`](@ref). [`BM25InvertedFile`](@ref)
+uses a `BM25` internally to answer top-k queries efficiently.
+
+# Fields
+`k1_plus_1`, `k1_mult_1_min_b`, and `k1_mult_b_div_avg_doc_len` are combinations of the
+BM25 `k1`/`b` hyperparameters and the corpus' average document length, precomputed for
+faster scoring; `δ` is the BM25+ lower-bound correction term; `trainsize` is the number
+of documents the corpus statistics were computed from.
+"""
 struct BM25
     #k1::Float32
     #b::Float32
@@ -26,6 +42,13 @@ function Base.show(io::IO, bm::BM25; prefix="", indent="  ")
 end
 
 
+"""
+    BM25(trainsize::Integer, avgdoclen::AbstractFloat; k1=1.2f0, b=0.75f0, δ=1f0)
+
+Creates a [`BM25`](@ref) scorer for a corpus of `trainsize` documents with average
+document length `avgdoclen`. `k1` controls term-frequency saturation, `b` controls
+document-length normalization, and `δ` is the BM25+ lower-bound correction.
+"""
 function BM25(trainsize::Integer, avgdoclen::AbstractFloat; k1=1.2f0, b=0.75f0, δ=1f0)
     BM25( #k1, b,
         convert(Float32, k1 + 1f0),
@@ -36,8 +59,20 @@ function BM25(trainsize::Integer, avgdoclen::AbstractFloat; k1=1.2f0, b=0.75f0, 
     )
 end
 
+"""
+    BM25(voc::Vocabulary; k1=1.2f0, b=0.75f0, δ=1f0)
+
+Creates a [`BM25`](@ref) scorer using the training size and average document length
+already computed in `voc` (see [`trainsize`](@ref) and [`avgdoclen`](@ref)).
+"""
 BM25(voc::Vocabulary; k1=1.2f0, b=0.75f0, δ=1f0) = BM25(trainsize(voc), avgdoclen(voc); k1, b, δ)
 
+"""
+    bm25score(bm25::BM25, voc::Vocabulary, query::Dict, doc::Dict)::Float32
+
+Computes the BM25 relevance score of `doc` (a bag of words) for `query` (a bag of words),
+summing [`tokenscore`](@ref) over every query token present in `doc`. Higher is more relevant.
+"""
 function bm25score(bm25::BM25, voc::Vocabulary, query::Dict, doc::Dict)::Float32
     s = 0f0
 
@@ -52,6 +87,14 @@ function bm25score(bm25::BM25, voc::Vocabulary, query::Dict, doc::Dict)::Float32
     s
 end
 
+"""
+    tokenscore(bm25::BM25, toknumdocs, doclen, tokfreqindoc)
+
+Computes the BM25 contribution of a single token to a document's score, given the
+number of documents containing the token (`toknumdocs`, i.e. its document frequency),
+the document's length in tokens (`doclen`), and the token's frequency in the document
+(`tokfreqindoc`). Used internally by [`bm25score`](@ref) and [`BM25InvertedFile`](@ref) search.
+"""
 function tokenscore(bm25::BM25, toknumdocs, doclen, tokfreqindoc)
     idf = log(1f0 + (bm25.trainsize - toknumdocs + 0.5f0) / (toknumdocs + 0.5f0))
     num = tokfreqindoc * bm25.k1_plus_1 

--- a/src/bm25invfile.jl
+++ b/src/bm25invfile.jl
@@ -9,9 +9,20 @@ using StatsBase
 
 
 """
-    struct BM25InvertedFile <: AbstractInvertedFile
+    BM25InvertedFile{AdjType<:AbstractAdjList} <: AbstractInvertedFile
 
-# Parameters
+An inverted-file index (built on top of `InvertedFiles.jl`) that answers approximate/exact
+top-k queries ranked by BM25 relevance. Build it with [`BM25InvertedFile(voc)`](@ref
+BM25InvertedFile), populate it with [`append_items!`](@ref)/[`push_item!`](@ref), and
+query it with `search` (from `SimilaritySearch.jl`).
+
+# Fields
+- `voc`: the [`Vocabulary`](@ref) shared by every indexed document (also used to
+  tokenize/encode query text).
+- `bm25`: the [`BM25`](@ref) scorer used to rank matches.
+- `adj`: the adjacency list of posting lists (one per token id), mapping each token to
+  the documents containing it and their term frequency.
+- `doclens`: number of tokens per indexed document.
 """
 struct BM25InvertedFile{AdjType<:AbstractAdjList} <: AbstractInvertedFile
     voc::Vocabulary
@@ -34,10 +45,11 @@ database(invfile::BM25InvertedFile) = error("database() is not accesible in BM25
 distance(::BM25InvertedFile) = error("BM25InvertedFile is not a metric index")
 
 """
-    BM25InvertedFile(voc::Vocabulary, db=nothing)
+    BM25InvertedFile(voc::Vocabulary; k1=1.2f0, b=0.75f0, δ=1f0)
 
-Fits the BM25 score from the given vocabulary it also creates the associated inverted file structure.
-
+Creates an empty [`BM25InvertedFile`](@ref), fitting its [`BM25`](@ref) scorer from `voc`
+(see [`BM25(voc)`](@ref BM25) for `k1`/`b`/`δ`). Populate it with
+[`append_items!`](@ref)/[`push_item!`](@ref).
 """
 function BM25InvertedFile(voc::Vocabulary;  k1=1.2f0, b=0.75f0, δ=1f0)
     bm25 = BM25(voc; k1, b, δ)
@@ -50,6 +62,23 @@ function BM25InvertedFile(voc::Vocabulary;  k1=1.2f0, b=0.75f0, δ=1f0)
     )
 end
 
+"""
+    filter_lists!(
+        idx::BM25InvertedFile;
+        list_min_length_for_checking::Int=96,
+        list_max_allowed_length::Int=1024,
+        doc_min_freq::Int=1,
+        doc_max_freq::Int=128,
+        always_sort::Bool=false
+    )
+
+Prunes each posting list of `idx` in place, once it is already populated. Lists shorter
+than `list_min_length_for_checking` are left untouched (optionally sorted by document id
+when `always_sort=true`). Longer lists are filtered to entries whose term frequency lies
+in `[doc_min_freq, doc_max_freq]`, then truncated to the `list_max_allowed_length`
+highest-frequency entries — this both discards overly rare/common (likely noisy) postings
+and bounds the cost of scanning very long lists at query time. Returns `idx`.
+"""
 function filter_lists!(
         idx::BM25InvertedFile;
         list_min_length_for_checking::Int=96,
@@ -91,6 +120,15 @@ function filter_lists!(
     idx
 end
 
+"""
+    append_items!(idx::BM25InvertedFile, ctx::InvertedFileContext, corpus; kwargs...)
+
+Adds every document in `corpus` to `idx`, computing each one's bag of words under
+`idx.voc` first. `corpus` can hold raw text (`AbstractString`), already-tokenized
+[`TokenizedText`](@ref), or pre-tokenized string vectors; a corpus of already-computed
+[`BOW`](@ref)s is accepted directly by the generic `SimilaritySearch.append_items!`
+method without going through this conversion. See also [`push_item!`](@ref).
+"""
 function append_items!(idx::BM25InvertedFile, ctx::InvertedFileContext, corpus::AbstractVector{T}; kwargs...) where {T<:AbstractString}
     append_items!(idx, ctx, VectorDatabase(bagofwords_corpus(idx.voc, corpus)); kwargs...)
 end
@@ -103,6 +141,15 @@ function append_items!(idx::BM25InvertedFile, ctx::InvertedFileContext, corpus::
     append_items!(idx, ctx, VectorDatabase(bagofwords_corpus(idx.voc, corpus)); kwargs...)
 end
 
+"""
+    push_item!(idx::BM25InvertedFile, ctx::InvertedFileContext, doc)
+
+Adds a single document `doc` to `idx`, computing its bag of words under `idx.voc` first.
+`doc` can be raw text (`AbstractString`), already-tokenized [`TokenizedText`](@ref), or a
+pre-tokenized string vector; an already-computed [`BOW`](@ref) is accepted directly by the
+generic `SimilaritySearch.push_item!` method without going through this conversion.
+See also [`append_items!`](@ref).
+"""
 function push_item!(idx::BM25InvertedFile, ctx::InvertedFileContext, doc::T) where {T<:Union{AbstractString,AbstractVector,TokenizedText}}
     push_item!(idx, ctx, bagofwords(idx.voc, doc))
 end

--- a/src/bm25invfile.jl
+++ b/src/bm25invfile.jl
@@ -23,6 +23,32 @@ query it with `search` (from `SimilaritySearch.jl`).
 - `adj`: the adjacency list of posting lists (one per token id), mapping each token to
   the documents containing it and their term frequency.
 - `doclens`: number of tokens per indexed document.
+
+# Example
+
+```julia
+julia> using SimilaritySearch
+
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> invfile = BM25InvertedFile(voc);
+
+julia> ctx = InvertedFileContext();
+
+julia> append_items!(invfile, ctx, corpus);
+
+julia> length(invfile)
+3
+
+julia> res = knnqueue(KnnSorted, 2);
+
+julia> search(invfile, ctx, "hello", res);
+
+julia> collect(IdView(res))
+UInt32[0x00000001, 0x00000002]
+```
 """
 struct BM25InvertedFile{AdjType<:AbstractAdjList} <: AbstractInvertedFile
     voc::Vocabulary
@@ -50,6 +76,17 @@ distance(::BM25InvertedFile) = error("BM25InvertedFile is not a metric index")
 Creates an empty [`BM25InvertedFile`](@ref), fitting its [`BM25`](@ref) scorer from `voc`
 (see [`BM25(voc)`](@ref BM25) for `k1`/`b`/`δ`). Populate it with
 [`append_items!`](@ref)/[`push_item!`](@ref).
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> invfile = BM25InvertedFile(voc);
+
+julia> length(invfile)
+0
+```
 """
 function BM25InvertedFile(voc::Vocabulary;  k1=1.2f0, b=0.75f0, δ=1f0)
     bm25 = BM25(voc; k1, b, δ)
@@ -78,6 +115,23 @@ when `always_sort=true`). Longer lists are filtered to entries whose term freque
 in `[doc_min_freq, doc_max_freq]`, then truncated to the `list_max_allowed_length`
 highest-frequency entries — this both discards overly rare/common (likely noisy) postings
 and bounds the cost of scanning very long lists at query time. Returns `idx`.
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> invfile = BM25InvertedFile(voc);
+
+julia> ctx = InvertedFileContext();
+
+julia> append_items!(invfile, ctx, corpus);
+
+julia> filter_lists!(invfile) === invfile
+true
+```
 """
 function filter_lists!(
         idx::BM25InvertedFile;
@@ -128,6 +182,21 @@ Adds every document in `corpus` to `idx`, computing each one's bag of words unde
 [`TokenizedText`](@ref), or pre-tokenized string vectors; a corpus of already-computed
 [`BOW`](@ref)s is accepted directly by the generic `SimilaritySearch.append_items!`
 method without going through this conversion. See also [`push_item!`](@ref).
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> invfile = BM25InvertedFile(voc);
+
+julia> ctx = InvertedFileContext();
+
+julia> append_items!(invfile, ctx, ["hello world", "hello there"]);
+
+julia> length(invfile)
+2
+```
 """
 function append_items!(idx::BM25InvertedFile, ctx::InvertedFileContext, corpus::AbstractVector{T}; kwargs...) where {T<:AbstractString}
     append_items!(idx, ctx, VectorDatabase(bagofwords_corpus(idx.voc, corpus)); kwargs...)
@@ -149,21 +218,39 @@ Adds a single document `doc` to `idx`, computing its bag of words under `idx.voc
 pre-tokenized string vector; an already-computed [`BOW`](@ref) is accepted directly by the
 generic `SimilaritySearch.push_item!` method without going through this conversion.
 See also [`append_items!`](@ref).
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> invfile = BM25InvertedFile(voc);
+
+julia> ctx = InvertedFileContext();
+
+julia> append_items!(invfile, ctx, corpus);
+
+julia> push_item!(invfile, ctx, "hello again");
+
+julia> length(invfile)
+3
+```
 """
 function push_item!(idx::BM25InvertedFile, ctx::InvertedFileContext, doc::T) where {T<:Union{AbstractString,AbstractVector,TokenizedText}}
     push_item!(idx, ctx, bagofwords(idx.voc, doc))
 end
 
-function SimilaritySearch.push_item!(idx::BM25InvertedFile, ctx::InvertedFileContext, obj; docID::UInt32=length(idx) + 1, tol::Float64=1e-6)
+function SimilaritySearch.push_item!(idx::BM25InvertedFile, ctx::InvertedFileContext, obj; docID::UInt32=UInt32(length(idx) + 1), tol::Float64=1e-6)
     len = bm25_internal_push_object!(idx, ctx, docID, obj, tol)
-    for (tokenID, _) in sparseiterator(obj)
+    for (tokenID, _) in InvertedFiles.sparseiterator(obj)
         N = neighbors(idx.adj, tokenID)
         N === nothing && continue
-        sort!(N)
+        sort!(N, by=p -> p.id)
     end
 
     push!(idx.doclens, len)
-    !isnothing(idx.db) && push_item!(idx.db, obj)
     LOG(ctx.logger, :push_item!, idx, ctx, docID, docID)
     idx
 end

--- a/src/bm25invfilesearch.jl
+++ b/src/bm25invfilesearch.jl
@@ -35,6 +35,29 @@ The `accept_posting_list` variant additionally receives a predicate called with 
 query token's posting list before scanning it, letting the caller skip lists (e.g. to
 implement stopword-like filtering at query time); it defaults to accepting every list.
 Returns `res`.
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> invfile = BM25InvertedFile(voc);
+
+julia> ctx = InvertedFileContext();
+
+julia> append_items!(invfile, ctx, corpus);
+
+julia> res = knnqueue(KnnSorted, 2);
+
+julia> search(invfile, ctx, "hello", res) do lst
+           true
+       end;
+
+julia> collect(IdView(res))
+UInt32[0x00000001, 0x00000002]
+```
 """
 function SimilaritySearch.search(accept_posting_list::Function, idx::BM25InvertedFile, ctx::InvertedFileContext, qtext::T, res::AbstractKnn) where {T<:Union{AbstractString,TokenizedText}}
     q = bagofwords(idx.voc, qtext)

--- a/src/bm25invfilesearch.jl
+++ b/src/bm25invfilesearch.jl
@@ -22,10 +22,19 @@ function Intersections.onmatch!(output::BM25InvFileOutput, L::T, P, m::Int) wher
 end
 
 """
-  search(accept_posting_list::Function, idx::BM25InvertedFile, ctx::InvertedFileContext, qtext::AbstractString, res::AbstractKnn
-  search(idx::BM25InvertedFile, ctx::InvertedFileContext, qtext::AbstractString, res::AbstractKnn
+    search(idx::BM25InvertedFile, ctx::InvertedFileContext, qtext, res::AbstractKnn)
+    search(accept_posting_list::Function, idx::BM25InvertedFile, ctx::InvertedFileContext, qtext, res::AbstractKnn; t::Int=1)
 
-Find candidates for solving query `Q` using `idx`. It calls `callback` on each candidate `(docID, dist)`
+Solves a top-k query over `idx` for `qtext` (raw text, [`TokenizedText`](@ref), or an
+already-computed bag of words), accumulating matches into `res` (an `AbstractKnn`, e.g.
+`KnnResult`/`KnnSorted`). Documents are ranked by BM25 score (stored internally as a
+negative value in `res`, so lower "distance" still means better match, consistent with
+`SimilaritySearch.jl`'s convention).
+
+The `accept_posting_list` variant additionally receives a predicate called with each
+query token's posting list before scanning it, letting the caller skip lists (e.g. to
+implement stopword-like filtering at query time); it defaults to accepting every list.
+Returns `res`.
 """
 function SimilaritySearch.search(accept_posting_list::Function, idx::BM25InvertedFile, ctx::InvertedFileContext, qtext::T, res::AbstractKnn) where {T<:Union{AbstractString,TokenizedText}}
     q = bagofwords(idx.voc, qtext)

--- a/src/bow.jl
+++ b/src/bow.jl
@@ -64,9 +64,10 @@ bagofwords(voc::Vocabulary, messages) = bagofwords_(copy, voc, messages)
 bagofwords(voc::Vocabulary, messages::BOW) = messages
 
 """
-    bagofwords_corpus(voc::Vocabulary, corpus::AbstractVector; minbatch=0)
+    bagofwords_corpus(voc::Vocabulary, corpus::AbstractVector; minbatch=0, verbose=true)
 
-Computes a list of bag of words from a corpus
+Computes a list of bag of words ([`BOW`](@ref)s) from a corpus, one per document,
+in parallel across threads.
 """
 bagofwords_corpus(voc::Vocabulary, corpus::AbstractVector{BOW}; minbatch=0, verbose=true) = corpus
 function bagofwords_corpus(voc::Vocabulary, corpus::AbstractVector; minbatch=0, verbose=true)

--- a/src/bow.jl
+++ b/src/bow.jl
@@ -7,6 +7,15 @@ export bagofwords_corpus, bagofwords
 
 Accumulates the tokens in `tokenlist` into `bow` (a [`BOW`](@ref)), looking up each
 token's id in `voc`; out-of-vocabulary tokens are skipped. Returns `bow`.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> TextSearch.bagofwords!(BOW(), voc, tokenize(TextConfig(), "hello hello"))
+Dict{UInt32, Int32}(0x00000001 => 2)
+```
 """
 function bagofwords!(bow::BOW, voc::Vocabulary, tokenlist::TokenizedText)
     for token in tokenlist
@@ -34,6 +43,19 @@ end
 
 Computes a bag of words from a multi-field document (a list of texts), storing the
 result in `buff.bow`. See [`bagofwords`](@ref) for the non-mutating version.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> buff = TextSearch.TextSearchBuffer();
+
+julia> TextSearch.bagofwords!(buff, voc, "hello hello world");
+
+julia> buff.bow
+Dict{UInt32, Int32}(0x00000002 => 1, 0x00000001 => 2)
+```
 """
 function bagofwords!(buff::TextSearchBuffer, voc::Vocabulary, messages)
     empty!(buff.bow)
@@ -63,6 +85,15 @@ end
 Tokenizes `messages` (a string or a list of strings) under `voc`'s [`TextConfig`](@ref)
 and returns its bag of words ([`BOW`](@ref)): a `token id => occurrence count` mapping.
 An already-computed [`BOW`](@ref) is returned unchanged.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> bagofwords(voc, "hello hello world")
+Dict{UInt32, Int32}(0x00000002 => 1, 0x00000001 => 2)
+```
 """
 bagofwords(voc::Vocabulary, messages) = bagofwords_(copy, voc, messages)
 bagofwords(voc::Vocabulary, messages::BOW) = messages
@@ -72,6 +103,15 @@ bagofwords(voc::Vocabulary, messages::BOW) = messages
 
 Computes a list of bag of words ([`BOW`](@ref)s) from a corpus, one per document,
 in parallel across threads.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> bagofwords_corpus(voc, ["hello world", "hello there"]; verbose=false)[1]
+Dict{UInt32, Int32}(0x00000002 => 1, 0x00000001 => 1)
+```
 """
 bagofwords_corpus(voc::Vocabulary, corpus::AbstractVector{BOW}; minbatch=0, verbose=true) = corpus
 function bagofwords_corpus(voc::Vocabulary, corpus::AbstractVector; minbatch=0, verbose=true)

--- a/src/bow.jl
+++ b/src/bow.jl
@@ -4,12 +4,9 @@ export bagofwords_corpus, bagofwords
 
 """
     bagofwords!(bow::BOW, voc::Vocabulary, tokenlist::TokenizedText)
-    bagofwords!(buff::TextSearchBuffer, voc::Vocabulary, text)
-    bagofwords(voc::Vocabulary, messages)
 
-Creates a bag of words from the given text (a string or a list of strings).
-If bow is given then updates the bag with the text.
-When `config` is given, the text is parsed according to it.
+Accumulates the tokens in `tokenlist` into `bow` (a [`BOW`](@ref)), looking up each
+token's id in `voc`; out-of-vocabulary tokens are skipped. Returns `bow`.
 """
 function bagofwords!(bow::BOW, voc::Vocabulary, tokenlist::TokenizedText)
     for token in tokenlist
@@ -33,10 +30,10 @@ function bagofwords_(copy_::Function, voc::Vocabulary, text)
 end
 
 """
-    bagofwords(voc::Vocabulary, messages)
-    bagofwords!(buff, voc::Vocabulary, messages)
+    bagofwords!(buff::TextSearchBuffer, voc::Vocabulary, messages)
 
-Computes a bag of words from messages
+Computes a bag of words from a multi-field document (a list of texts), storing the
+result in `buff.bow`. See [`bagofwords`](@ref) for the non-mutating version.
 """
 function bagofwords!(buff::TextSearchBuffer, voc::Vocabulary, messages)
     empty!(buff.bow)
@@ -60,6 +57,13 @@ function bagofwords!(buff::TextSearchBuffer, voc::Vocabulary, tokens::TokenizedT
     buff
 end
 
+"""
+    bagofwords(voc::Vocabulary, messages)
+
+Tokenizes `messages` (a string or a list of strings) under `voc`'s [`TextConfig`](@ref)
+and returns its bag of words ([`BOW`](@ref)): a `token id => occurrence count` mapping.
+An already-computed [`BOW`](@ref) is returned unchanged.
+"""
 bagofwords(voc::Vocabulary, messages) = bagofwords_(copy, voc, messages)
 bagofwords(voc::Vocabulary, messages::BOW) = messages
 

--- a/src/dvec.jl
+++ b/src/dvec.jl
@@ -50,6 +50,17 @@ Base.minimum(voc::Dict) = first(findmin(voc))
     normalize!(bow::Dict)
 
 Inplace normalization of `bow`
+
+# Example
+
+```julia
+julia> using LinearAlgebra
+
+julia> a = Dict{UInt32,Float32}(1 => 3.0, 2 => 4.0);
+
+julia> normalize!(a)
+Dict{UInt32, Float32}(0x00000002 => 0.8, 0x00000001 => 0.6)
+```
 """
 function normalize!(bow::Dict)
     s = one(valtype(bow)) / norm(bow)
@@ -121,6 +132,15 @@ end
     dot(a::Dict, b::Dict)
 
 Computes the dot product for two Dict vectors
+
+# Example
+
+```julia
+julia> using LinearAlgebra
+
+julia> dot(Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8), Dict{UInt32,Float32}(2 => 1.0))
+0.8f0
+```
 """
 function dot(a::Dict, b::Dict)
     if length(b) < length(a)
@@ -140,6 +160,15 @@ end
     norm(a::Dict)
 
 Computes a normalized Dict vector
+
+# Example
+
+```julia
+julia> using LinearAlgebra
+
+julia> norm(Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8))
+1.0f0
+```
 """
 function norm(a::Dict)
     s = zero(valtype(a))
@@ -166,6 +195,15 @@ end
     add!(a::Dict{Ti,Tv}, b::Pair{Ti,Tv}) where {Ti,Tv<:Real}
 
 Updates `a` to the sum of `a+b`
+
+# Example
+
+```julia
+julia> a = Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8);
+
+julia> TextSearch.add!(a, Dict{UInt32,Float32}(2 => 0.5))
+Dict{UInt32, Float32}(0x00000002 => 1.3, 0x00000001 => 0.6)
+```
 """
 function add!(a::Dict{Ti,Tv}, b::Dict{Ti,Tv}) where {Ti,Tv<:Real}
     for (k, w) in b
@@ -212,6 +250,13 @@ end
     centroid(cluster::AbstractVector{<:Dict})
 
 Computes a centroid of the given list of Dict vectors
+
+# Example
+
+```julia
+julia> centroid([Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8), Dict{UInt32,Float32}(2 => 1.0)])
+Dict{UInt32, Float32}(0x00000002 => 0.9486834, 0x00000001 => 0.3162278)
+```
 """
 function centroid(cluster::AbstractVector{<:Dict})
     normalize!(sum(cluster))
@@ -222,6 +267,13 @@ end
     +(a::Dict, b::Pair)
 
 Computes the sum of `a` and `b`
+
+# Example
+
+```julia
+julia> Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8) + Dict{UInt32,Float32}(2 => 1.0)
+Dict{UInt32, Float32}(0x00000002 => 1.8, 0x00000001 => 0.6)
+```
 """
 function +(a::Dict{Ti,Tv}, b::Dict{Ti,Tv}) where {Ti,Tv<:Real}
     if length(a) < length(b)
@@ -249,6 +301,13 @@ end
     -(a::Dict{Ti,Tv}, b::Dict{Ti,Tv}) where {Ti,Tv<:Real}
 
 Substracts of `b` of `a`
+
+# Example
+
+```julia
+julia> Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8) - Dict{UInt32,Float32}(2 => 1.0)
+Dict{UInt32, Float32}(0x00000002 => -0.19999999, 0x00000001 => 0.6)
+```
 """
 function -(a::Dict{Ti,Tv}, b::Dict{Ti,Tv}) where {Ti,Tv<:Real}
     c = copy(a)
@@ -267,6 +326,16 @@ end
     *(a::Dict{K, V}, b::F) where K where {V<:Real} where {F<:Real}
 
 Computes the element-wise product of a and b
+
+# Example
+
+```julia
+julia> Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8) * Dict{UInt32,Float32}(2 => 1.0)
+Dict{UInt32, Float32}(0x00000002 => 0.8)
+
+julia> Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8) * 2.0
+Dict{UInt32, Float32}(0x00000002 => 1.6, 0x00000001 => 1.2)
+```
 """
 function *(a::Dict{Ti,Tv}, b::Dict{Ti,Tv}) where {Ti,Tv<:Real}
     if length(b) < length(a)
@@ -303,6 +372,13 @@ end
     /(a::Dict{K, V}, b::F) where K where {V<:Real} where {F<:Real}
 
 Computes the element-wise division of a and b
+
+# Example
+
+```julia
+julia> Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8) / 2.0
+Dict{UInt32, Float32}(0x00000002 => 0.4, 0x00000001 => 0.3)
+```
 """
 function /(a::Dict{K,V}, b::F) where K where {V<:Real} where {F<:Real}
     a * (1.0 / b)
@@ -316,6 +392,12 @@ Computes the cosine distance between two Dict sparse vectors
 
 It supposes that bags are normalized (see `normalize!` function)
 
+# Example
+
+```julia
+julia> evaluate(NormCosine(), Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8), Dict{UInt32,Float32}(2 => 1.0))
+0.19999998807907104
+```
 """
 function evaluate(::NormCosine, a::Dict, b::Dict)::Float64
     1.0 - dot(a, b)
@@ -324,8 +406,15 @@ end
 """
     evaluate(::Cosine, a::Dict, b::Dict)::Float64
 
-Computes the cosine distance between two Dict sparse vectors
+Computes the cosine distance between two Dict sparse vectors (unlike `NormCosine`,
+`a`/`b` need not be pre-normalized).
 
+# Example
+
+```julia
+julia> evaluate(Cosine(), Dict{UInt32,Float32}(1 => 3.0, 2 => 4.0), Dict{UInt32,Float32}(2 => 1.0))
+0.19999998807907104
+```
 """
 function evaluate(::Cosine, a::Dict, b::Dict)::Float64
     1.0 - full_cosine(a, b)
@@ -340,6 +429,12 @@ Computes the angle  between two Dict sparse vectors
 
 It supposes that all bags are normalized (see `normalize!` function)
 
+# Example
+
+```julia
+julia> evaluate(NormAngle(), Dict{UInt32,Float32}(1 => 0.6, 2 => 0.8), Dict{UInt32,Float32}(2 => 1.0))
+0.6435011029243469
+```
 """
 function evaluate(::NormAngle, a::Dict, b::Dict)::Float64
     d = dot(a, b)
@@ -358,8 +453,15 @@ end
 """
     evaluate(::Angle, a::Dict, b::Dict)::Float64
 
-Computes the angle between two Dict sparse vectors
+Computes the angle between two Dict sparse vectors (unlike `NormAngle`, `a`/`b`
+need not be pre-normalized).
 
+# Example
+
+```julia
+julia> evaluate(Angle(), Dict{UInt32,Float32}(1 => 3.0, 2 => 4.0), Dict{UInt32,Float32}(2 => 1.0))
+0.6435010889250692
+```
 """
 function evaluate(::Angle, a::Dict, b::Dict)::Float64
     d = full_cosine(a, b)

--- a/src/emodel.jl
+++ b/src/emodel.jl
@@ -3,22 +3,51 @@
 #####
 export EntropyWeighting, NormalizedEntropy, SigmoidPenalizeFewSamples, CombineWeighting
 
+"""
+    CombineWeighting
+
+Abstract type for the strategies that turn a per-token, per-class distribution and its
+empirical entropy into a single global weight (via the internal `combine_weight`
+function), used by [`EntropyWeighting`](@ref). Available strategies:
+[`NormalizedEntropy`](@ref) and [`SigmoidPenalizeFewSamples`](@ref).
+"""
 abstract type CombineWeighting end
+
+"""
+    NormalizedEntropy()
+
+A [`CombineWeighting`](@ref) that weights a token as `1 - entropy / maxent`: tokens that
+discriminate well between classes (low entropy) get a weight close to `1`, tokens spread
+uniformly across classes (entropy close to `maxent`) get a weight close to `0`.
+"""
 struct NormalizedEntropy <: CombineWeighting end
-combine_weight(::NormalizedEntropy, model, tokenID, entropy, maxent)::Float32 = 1.0 - entropy / maxent 
+combine_weight(::NormalizedEntropy, model, tokenID, entropy, maxent)::Float32 = 1.0 - entropy / maxent
 # the entropy scores the discrimination power of the term while log(m) weights
 # the term w.r.t the available evidency. The current form tries to equalize the
 # scales
 struct PenalizeFewSamples <: CombineWeighting end
-combine_weight(::PenalizeFewSamples, model, tokenID, entropy, maxent)::Float32 = (maxent - entropy) * log2(ndocs(model, tokenID)) 
+combine_weight(::PenalizeFewSamples, model, tokenID, entropy, maxent)::Float32 = (maxent - entropy) * log2(ndocs(model, tokenID))
 
+"""
+    SigmoidPenalizeFewSamples()
+
+Like [`NormalizedEntropy`](@ref), but additionally down-weights tokens seen in very few
+documents (low `ndocs`) via a sigmoid-like penalty on `log2(ndocs)`, so that rare tokens
+don't get an unduly high weight just because they appear in a single class.
+"""
 struct SigmoidPenalizeFewSamples <: CombineWeighting end
 combine_weight(::SigmoidPenalizeFewSamples, model, tokenID, entropy, maxent)::Float32 = (1 - entropy/maxent) * (1-1/(1+log2(ndocs(model, tokenID))))
 
 """
-    EntropyWeighting(; smooth=0.0, lowerweight=0.0, weights=:balance)
+    EntropyWeighting()
 
-Entropy weighting uses the empirical entropy of the vocabulary along classes to produce a notion of importance for each token
+A [`GlobalWeighting`](@ref) that scores each token by the empirical entropy of its
+occurrences across document classes/labels, instead of the plain document frequency used
+by [`IdfWeighting`](@ref) — tokens whose occurrences concentrate on few classes get a
+higher weight than tokens spread uniformly across all classes. Since it needs document
+labels, it is not built via the generic [`VectorModel(gw, lw, voc)`](@ref VectorModel)
+constructor; use [`VectorModel(::EntropyWeighting, lw, voc, corpus, labels)`](@ref
+VectorModel) instead.
 """
 struct EntropyWeighting <: GlobalWeighting end
 
@@ -39,14 +68,28 @@ end
 
 
 """
-    VectorModel(ent::EntropyWeighting, lw::LocalWeighting, corpus::BOW, labels;
-        mindocs::Integer=1,
-        smooth::Float64=0.0,
-        weights=:balance
+    VectorModel(ent::EntropyWeighting, lw::LocalWeighting, voc::Vocabulary, corpus::AbstractVector, labels::AbstractVector;
+        mindocs=3,
+        smooth=3,
+        weights=:balance,
         comb::CombineWeighting=NormalizedEntropy(),
+        minbatch=0, verbose=true
     )
 
-Creates a vector model using the input corpus. 
+Creates a [`VectorModel`](@ref) with [`EntropyWeighting`](@ref) as its global weighting
+scheme. Unlike the generic [`VectorModel(gw, lw, voc)`](@ref VectorModel) constructor,
+this one needs the actual `corpus` and a matching `labels` vector (one label per
+document) to compute, for each token, its occurrence distribution across classes and the
+resulting entropy-based weight.
+
+- `mindocs`: tokens occurring in fewer than `mindocs` documents get weight `0`.
+- `smooth`: additive (Laplace-like) smoothing applied to the per-class occurrence counts
+  before computing entropy, to avoid zero counts.
+- `weights`: how to reweight classes before computing entropy — `:balance` compensates
+  for class-size imbalance, `:none` (or `nothing`) leaves classes unweighted, or pass an
+  `AbstractVector` of per-class weights directly.
+- `comb`: the [`CombineWeighting`](@ref) strategy combining entropy and evidence into the
+  final per-token weight.
 """
 function VectorModel(ent::EntropyWeighting, lw::LocalWeighting, voc::Vocabulary, corpus::AbstractVector, labels::AbstractVector;
             mindocs=3,

--- a/src/emodel.jl
+++ b/src/emodel.jl
@@ -19,6 +19,21 @@ abstract type CombineWeighting end
 A [`CombineWeighting`](@ref) that weights a token as `1 - entropy / maxent`: tokens that
 discriminate well between classes (low entropy) get a weight close to `1`, tokens spread
 uniformly across classes (entropy close to `maxent`) get a weight close to `0`.
+
+# Example
+
+```julia
+julia> corpus = ["me gusta", "me encanta", "no me gusta", "odio esto"];
+
+julia> labels = ["pos", "pos", "neg", "neg"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(EntropyWeighting(), TfWeighting(), voc, corpus, labels; mindocs=1, comb=NormalizedEntropy(), verbose=false);
+
+julia> vectorize(model, "me gusta")
+Dict{UInt32, Float32}(0x00000002 => 0.02782909, 0x00000001 => 0.9996127)
+```
 """
 struct NormalizedEntropy <: CombineWeighting end
 combine_weight(::NormalizedEntropy, model, tokenID, entropy, maxent)::Float32 = 1.0 - entropy / maxent
@@ -34,6 +49,21 @@ combine_weight(::PenalizeFewSamples, model, tokenID, entropy, maxent)::Float32 =
 Like [`NormalizedEntropy`](@ref), but additionally down-weights tokens seen in very few
 documents (low `ndocs`) via a sigmoid-like penalty on `log2(ndocs)`, so that rare tokens
 don't get an unduly high weight just because they appear in a single class.
+
+# Example
+
+```julia
+julia> corpus = ["me gusta", "me encanta", "no me gusta", "odio esto"];
+
+julia> labels = ["pos", "pos", "neg", "neg"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(EntropyWeighting(), TfWeighting(), voc, corpus, labels; mindocs=1, comb=SigmoidPenalizeFewSamples(), verbose=false);
+
+julia> vectorize(model, "me gusta")
+Dict{UInt32, Float32}(0x00000002 => 0.02269659, 0x00000001 => 0.99974245)
+```
 """
 struct SigmoidPenalizeFewSamples <: CombineWeighting end
 combine_weight(::SigmoidPenalizeFewSamples, model, tokenID, entropy, maxent)::Float32 = (1 - entropy/maxent) * (1-1/(1+log2(ndocs(model, tokenID))))
@@ -48,6 +78,21 @@ higher weight than tokens spread uniformly across all classes. Since it needs do
 labels, it is not built via the generic [`VectorModel(gw, lw, voc)`](@ref VectorModel)
 constructor; use [`VectorModel(::EntropyWeighting, lw, voc, corpus, labels)`](@ref
 VectorModel) instead.
+
+# Example
+
+```julia
+julia> corpus = ["me gusta", "me encanta", "no me gusta", "odio esto"];
+
+julia> labels = ["pos", "pos", "neg", "neg"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(EntropyWeighting(), TfWeighting(), voc, corpus, labels; verbose=false);
+
+julia> vectorize(model, "me gusta")
+Dict{UInt32, Float32}(0x00000001 => 1.0)
+```
 """
 struct EntropyWeighting <: GlobalWeighting end
 
@@ -90,6 +135,21 @@ resulting entropy-based weight.
   `AbstractVector` of per-class weights directly.
 - `comb`: the [`CombineWeighting`](@ref) strategy combining entropy and evidence into the
   final per-token weight.
+
+# Example
+
+```julia
+julia> corpus = ["me gusta", "me encanta", "no me gusta", "odio esto"];
+
+julia> labels = ["pos", "pos", "neg", "neg"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(EntropyWeighting(), TfWeighting(), voc, corpus, labels; mindocs=1, verbose=false);
+
+julia> vectorize(model, "me gusta")
+Dict{UInt32, Float32}(0x00000002 => 0.02782909, 0x00000001 => 0.9996127)
+```
 """
 function VectorModel(ent::EntropyWeighting, lw::LocalWeighting, voc::Vocabulary, corpus::AbstractVector, labels::AbstractVector;
             mindocs=3,

--- a/src/normalize.jl
+++ b/src/normalize.jl
@@ -23,6 +23,16 @@ const RE_NUM = r"[-+]?(\d+\.?\d*)|(\.\d+)"
 
 Tests whether `c` is one of the emoji characters known to TextSearch (loaded from
 `emojis.txt`). Used by [`normalize_text`](@ref) when `TextConfig`'s `group_emo` option is set.
+
+# Example
+
+```julia
+julia> isemoji('😀')
+true
+
+julia> isemoji('a')
+false
+```
 """
 function isemoji(c::Char)
     c in EMOJIS
@@ -52,6 +62,17 @@ end
     normalize_text(config::TextConfig, text::AbstractString, output::Vector{Char}; limits::Bool=true)
 
 Normalizes a given text using the specified transformations of `config`
+
+# Example
+
+```julia
+julia> buff = Char[];
+
+julia> normalize_text(TextConfig(), "Café", buff);
+
+julia> String(buff)
+" cafe "
+```
 """
 function normalize_text(config::TextConfig, text::AbstractString, output::Vector{Char}; limits::Bool=true)
     text = _preprocessing(config, text)

--- a/src/normalize.jl
+++ b/src/normalize.jl
@@ -18,6 +18,12 @@ const RE_USER = r"""@[^;:,.@#&\\\-\"'/:\*\(\)\[\]\¿\?\¡\!\{\}~\<\>\|\s]+"""
 const RE_URL = r"(http|ftp|https)://\S+"
 const RE_NUM = r"[-+]?(\d+\.?\d*)|(\.\d+)"
 
+"""
+    isemoji(c::Char)::Bool
+
+Tests whether `c` is one of the emoji characters known to TextSearch (loaded from
+`emojis.txt`). Used by [`normalize_text`](@ref) when `TextConfig`'s `group_emo` option is set.
+"""
 function isemoji(c::Char)
     c in EMOJIS
 end

--- a/src/sparseconversions.jl
+++ b/src/sparseconversions.jl
@@ -8,6 +8,13 @@ export dvec, sparse_coo, sparse
     dvec(x::AbstractSparseVector)
 
 Converts an sparse vector into a dict-based sparse vector
+
+# Example
+
+```julia
+julia> dvec(sparsevec(Dict{UInt32,Float32}(1 => 0.5, 3 => 0.2)))
+Dict{UInt32, Float32}(0x00000003 => 0.2, 0x00000001 => 0.5)
+```
 """
 function dvec(x::AbstractSparseVector)
     Dict{eltype(x.nzind),eltype(x.nzval)}(t => v for (t, v) in zip(x.nzind, x.nzval))
@@ -17,6 +24,14 @@ end
     sparsevec(vec::Dict{Ti,Tv}, m=0) where {Ti<:Integer,Tv<:Number}
 
 Creates a sparse vector from a Dict-based sparse vector
+
+# Example
+
+```julia
+julia> sparsevec(Dict{UInt32,Float32}(1 => 0.5, 3 => 0.2))
+  [1]  =  0.5
+  [3]  =  0.2
+```
 """
 function sparsevec(vec::Dict{Ti,Tv}, m::Integer=0) where {Ti<:Integer,Tv<:Number}
     I = Ti[]
@@ -43,6 +58,17 @@ end
     sparse_coo(cols::AbstractVector{<:Dict}, minweight=1e-9)
 
 Creates a sparse matrix from an array of Dict sparse vectors.
+
+# Example
+
+```julia
+julia> cols = [Dict{UInt32,Float32}(1 => 0.5), Dict{UInt32,Float32}(2 => 0.8)];
+
+julia> Matrix(sparse(cols))
+2×2 Matrix{Float32}:
+ 0.5  0.0
+ 0.0  0.8
+```
 """
 function sparse_coo(cols::AbstractVector{S}, minweight=1e-9) where {S<:Dict}
     I = keytype(S)[]

--- a/src/textconfig.jl
+++ b/src/textconfig.jl
@@ -6,6 +6,13 @@ export TextConfig, Skipgram
     Skipgram(qsize, skip)
 
 A skipgram is a kind of tokenization where `qsize` words having `skip` separation are used as a single token.
+
+# Example
+
+```julia
+julia> collect(tokenize(TextConfig(slist=[Skipgram(2, 1)]), "the cat sat down"))
+["the sat\ts", "cat down\ts"]
+```
 """
 struct Skipgram
     qsize::Int8
@@ -55,6 +62,15 @@ Defines a preprocessing and tokenization pipeline
 - `tt`: An `AbstractTokenTransformation` struct
 
 Note: If qlist, nlist, and slists are all empty arrays, then it defaults to nlist=[1]
+
+# Example
+
+```julia
+julia> cfg = TextConfig(nlist=[1], qlist=[3]);
+
+julia> collect(tokenize(cfg, "cats"))
+[" ca\tq", "cat\tq", "ats\tq", "ts \tq", "cats"]
+```
 """
 Base.@kwdef struct TextConfig
     del_diac::Bool  = true

--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -2,8 +2,16 @@
 
 export TokenizedText, tokenize, tokenize_corpus, qgrams, unigrams, filter_tokens!
 
+"""
+    TokenizedText(tokens::AbstractVector{String})
+
+Wraps the token list produced by [`tokenize`](@ref) for a single document. Behaves like
+an `AbstractVector{String}` (it supports indexing, iteration, `push!`, `append!`, etc.)
+and is the type consumed by [`bagofwords`](@ref)/[`bagofwords!`](@ref) and by
+[`Vocabulary`](@ref)-building functions.
+"""
 struct TokenizedText{StringVector<:AbstractVector{String}}
-    tokens::StringVector 
+    tokens::StringVector
 end
 
 @inline Base.getindex(T::TokenizedText, i::Integer) = T.tokens[i]
@@ -72,6 +80,13 @@ function tokenize(copy_::Function, textconfig::TextConfig, text)
     end
 end
 
+"""
+    normalize_text(textconfig::TextConfig, text; limits::Bool=false)
+
+Convenience method that normalizes `text` under `textconfig` (see
+[`normalize_text(config, text, output; limits)`](@ref normalize_text)) and returns the
+result as a `String` instead of writing into a caller-provided buffer.
+"""
 function normalize_text(textconfig::TextConfig, text; limits::Bool=false)
     buff = take!(TEXT_SEARCH_CACHES)
     empty!(buff)

--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -9,6 +9,13 @@ Wraps the token list produced by [`tokenize`](@ref) for a single document. Behav
 an `AbstractVector{String}` (it supports indexing, iteration, `push!`, `append!`, etc.)
 and is the type consumed by [`bagofwords`](@ref)/[`bagofwords!`](@ref) and by
 [`Vocabulary`](@ref)-building functions.
+
+# Example
+
+```julia
+julia> collect(tokenize(TextConfig(), "Hello world!!"))
+["hello", "world", "!!"]
+```
 """
 struct TokenizedText{StringVector<:AbstractVector{String}}
     tokens::StringVector
@@ -48,6 +55,12 @@ and when these buffers are shared it is mandatory to create a copy of the result
 Change the default `copy` function to make an additional filtering of the tokens.
 You can also pass the `identity` function to avoid copying.
 
+# Example
+
+```julia
+julia> collect(tokenize(TextConfig(), "Hello world!!"))
+["hello", "world", "!!"]
+```
 """
 function tokenize(copy_::Function, textconfig::TextConfig, text::AbstractString, buff::TextSearchBuffer)
     normalize_text(textconfig, text, buff.normtext)
@@ -86,6 +99,13 @@ end
 Convenience method that normalizes `text` under `textconfig` (see
 [`normalize_text(config, text, output; limits)`](@ref normalize_text)) and returns the
 result as a `String` instead of writing into a caller-provided buffer.
+
+# Example
+
+```julia
+julia> normalize_text(TextConfig(), "Café!!")
+"cafe!!"
+```
 """
 function normalize_text(textconfig::TextConfig, text; limits::Bool=false)
     buff = take!(TEXT_SEARCH_CACHES)
@@ -103,6 +123,17 @@ end
     tokenize_corpus(copy_::Function, textconfig::TextConfig, arr; minbatch=0, verbose=true)
 
 Tokenize a list of texts. The `copy_` function is passed to [`tokenize`](@ref) as first argument.
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "the cat sat"];
+
+julia> toks = tokenize_corpus(TextConfig(), corpus; verbose=false);
+
+julia> collect(toks[1])
+["hello", "world"]
+```
 """
 function tokenize_corpus(copy_::Function, textconfig::TextConfig, arr; minbatch::Int=0, verbose::Bool=true)
     n = length(arr)

--- a/src/tokentrans.jl
+++ b/src/tokentrans.jl
@@ -3,7 +3,23 @@
 export TextConfig, Skipgram, AbstractTokenTransformation, IdentityTokenTransformation
 export IgnoreStopwords, ChainTransformation
 
+"""
+    AbstractTokenTransformation
+
+Abstract type for token transformation hooks applied during tokenization (see
+[`transform_unigram`](@ref), [`transform_nword`](@ref), [`transform_qgram`](@ref),
+[`transform_skipgram`](@ref), and [`transform_collocation`](@ref)). A [`TextConfig`](@ref)
+holds one such transformation in its `tt` field; it is applied to every generated token
+before it is pushed to the token list, and can be used to implement stemming, casing
+rules, or stopword removal (by returning `nothing`).
+"""
 abstract type AbstractTokenTransformation end
+
+"""
+    IdentityTokenTransformation()
+
+The default, no-op [`AbstractTokenTransformation`](@ref): every token is kept unchanged.
+"""
 struct IdentityTokenTransformation <: AbstractTokenTransformation end
 
 """
@@ -53,6 +69,13 @@ transform_skipgram(::AbstractTokenTransformation, tok) = tok
 
 ### some transformations
 
+"""
+    IgnoreStopwords(stopwords::Set{String})
+
+An [`AbstractTokenTransformation`](@ref) that discards unigrams found in `stopwords`
+(returns `nothing` for them, causing the tokenizer to drop the token) and passes every
+other token through unchanged.
+"""
 struct IgnoreStopwords <: AbstractTokenTransformation
     stopwords::Set{String}
 end
@@ -61,6 +84,16 @@ function TextSearch.transform_unigram(tt::IgnoreStopwords, tok)
     tok in tt.stopwords ? nothing : tok
 end
 
+"""
+    ChainTransformation(list::AbstractVector{<:AbstractTokenTransformation})
+
+Holds an ordered sequence of [`AbstractTokenTransformation`](@ref)s, meant to be applied
+one after the other over each token.
+
+!!! note
+    `transform_unigram`/`transform_nword`/etc. are not yet specialized for
+    `ChainTransformation`; it currently falls back to the identity behavior.
+"""
 struct ChainTransformation <: AbstractTokenTransformation
-    list::AbstractVector{<:AbstractTokenTransformation}    
+    list::AbstractVector{<:AbstractTokenTransformation}
 end

--- a/src/tokentrans.jl
+++ b/src/tokentrans.jl
@@ -19,6 +19,13 @@ abstract type AbstractTokenTransformation end
     IdentityTokenTransformation()
 
 The default, no-op [`AbstractTokenTransformation`](@ref): every token is kept unchanged.
+
+# Example
+
+```julia
+julia> collect(tokenize(TextConfig(tt=IdentityTokenTransformation()), "the cat sat"))
+["the", "cat", "sat"]
+```
 """
 struct IdentityTokenTransformation <: AbstractTokenTransformation end
 
@@ -75,6 +82,15 @@ transform_skipgram(::AbstractTokenTransformation, tok) = tok
 An [`AbstractTokenTransformation`](@ref) that discards unigrams found in `stopwords`
 (returns `nothing` for them, causing the tokenizer to drop the token) and passes every
 other token through unchanged.
+
+# Example
+
+```julia
+julia> cfg = TextConfig(nlist=[1], tt=IgnoreStopwords(Set(["the", "a"])));
+
+julia> collect(tokenize(cfg, "the cat sat"))
+["cat", "sat"]
+```
 """
 struct IgnoreStopwords <: AbstractTokenTransformation
     stopwords::Set{String}
@@ -93,6 +109,15 @@ one after the other over each token.
 !!! note
     `transform_unigram`/`transform_nword`/etc. are not yet specialized for
     `ChainTransformation`; it currently falls back to the identity behavior.
+
+# Example
+
+```julia
+julia> ct = ChainTransformation([IdentityTokenTransformation(), IgnoreStopwords(Set(["the"]))]);
+
+julia> ct isa AbstractTokenTransformation
+true
+```
 """
 struct ChainTransformation <: AbstractTokenTransformation
     list::AbstractVector{<:AbstractTokenTransformation}

--- a/src/updatevoc.jl
+++ b/src/updatevoc.jl
@@ -6,6 +6,19 @@ Update `voc` vocabulary using another vocabulary. Optionally a predicate can be 
 
 Note 1: `corpuslen` remains unchanged (the structure is immutable and a new `Vocabulary` should be created to update this field).
 Note 2: Both `voc` and `another` vocabularies should had been created with a _compatible_ [`TextConfig`](@ref) to be able to work on them.
+
+# Example
+
+```julia
+julia> cfg = TextConfig();
+
+julia> voc = Vocabulary(cfg, 0, 0);
+
+julia> update_voc!(voc, Vocabulary(cfg, ["hello world"]; verbose=false));
+
+julia> vocsize(voc)
+2
+```
 """
 update_voc!(voc::Vocabulary, another::Vocabulary) = update_voc!(t->true, voc, another)
 
@@ -26,6 +39,17 @@ end
     filter_tokens!(voc::Vocabulary, text::TokenizedText)
 
 Removes tokens from a given tokenized text based using the valid vocabulary
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> tks = tokenize(TextConfig(), "hello unknownword world");
+
+julia> filter_tokens!(voc, tks); collect(tks)
+["hello", "world"]
+```
 """
 function filter_tokens!(voc::Vocabulary, text::TokenizedText)
     j = 0
@@ -61,6 +85,19 @@ end
 Merges two or more vocabularies into a new one. A predicate function can be used to filter token entries.
 
 Note: All vocabularies should had been created with a _compatible_ [`TextConfig`](@ref) to be able to work on them.
+
+# Example
+
+```julia
+julia> cfg = TextConfig();
+
+julia> voc1 = Vocabulary(cfg, ["hello world"]; verbose=false);
+
+julia> voc2 = Vocabulary(cfg, ["hello there"]; verbose=false);
+
+julia> vocsize(merge_voc(voc1, voc2))
+3
+```
 """
 merge_voc(voc1::Vocabulary, voc2::Vocabulary, voclist...) = merge_voc(x->true, voc1, voc2, voclist...)
 
@@ -86,6 +123,17 @@ end
     filter_tokens(pred::Function, voc::Vocabulary)
 
 Returns a copy of reduced vocabulary based on evaluating `pred` function for each entry in `voc`
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> voc2 = filter_tokens(t -> t.ndocs >= 2, voc);
+
+julia> vocsize(voc2)
+1
+```
 """
 function filter_tokens(pred::Function, voc::Vocabulary)
     V = Vocabulary(voc.textconfig, trainsize(voc), numtokens(voc))

--- a/src/updatevoc.jl
+++ b/src/updatevoc.jl
@@ -42,9 +42,9 @@ function filter_tokens!(voc::Vocabulary, text::TokenizedText)
 end
 
 """
-    filter_tokens!(voc::Vocabulary, text::TokenizedText)
+    filter_tokens!(voc::Vocabulary, arr::AbstractVector{TokenizedText})
 
-Removes tokens from text array
+Applies [`filter_tokens!(voc, text)`](@ref filter_tokens!) to every tokenized document in `arr`.
 """
 function filter_tokens!(voc::Vocabulary, arr::AbstractVector{TokenizedText})
     for t in arr

--- a/src/vmodel.jl
+++ b/src/vmodel.jl
@@ -79,12 +79,27 @@ struct BinaryGlobalWeighting <: GlobalWeighting end
 ##
 #####
 """
-    Model
+    TextModel
 
-An abstract type that represents a weighting model
+Abstract type for text-to-vector weighting models (see [`VectorModel`](@ref)).
 """
 abstract type TextModel end
 
+"""
+    VectorModel{_G<:GlobalWeighting, _L<:LocalWeighting}
+
+Combines a [`Vocabulary`](@ref) with a local/global term-weighting scheme
+(e.g. [`TfWeighting`](@ref)+[`IdfWeighting`](@ref) for classical TF-IDF) to turn
+bags of words into weighted sparse vectors (`SVEC`) via [`vectorize`](@ref)/[`vectorize!`](@ref).
+Build one with [`VectorModel(gw, lw, voc)`](@ref VectorModel).
+
+# Fields
+- `global_weighting`: the [`GlobalWeighting`](@ref) scheme (e.g. IDF), applied per-token, corpus-wide.
+- `local_weighting`: the [`LocalWeighting`](@ref) scheme (e.g. TF), applied per-token, per-document.
+- `voc`: the underlying [`Vocabulary`](@ref).
+- `maxoccs`: maximum per-token occurrence count in `voc`, used by some local weightings.
+- `weight`: precomputed per-token global weight (`weight[tokenID]`).
+"""
 mutable struct VectorModel{_G<:GlobalWeighting, _L<:LocalWeighting} <: TextModel
     global_weighting::_G
     local_weighting::_L
@@ -102,6 +117,14 @@ function Base.show(io::IO, model::VectorModel; prefix="", indent="  ")
     show(io, model.voc; prefix, indent)
 end
 
+"""
+    VectorModel(gw::GlobalWeighting, lw::LocalWeighting, voc::Vocabulary; weight=nothing)
+
+Creates a [`VectorModel`](@ref) for the given vocabulary `voc` using the local weighting
+`lw` (e.g. [`TfWeighting`](@ref)) and global weighting `gw` (e.g. [`IdfWeighting`](@ref)).
+The per-token global weight vector is computed from `voc` unless `weight` is given
+explicitly (e.g. when reusing weights computed elsewhere, such as [`EntropyWeighting`](@ref)).
+"""
 function VectorModel(gw::GlobalWeighting, lw::LocalWeighting, voc::Vocabulary; weight=nothing)
     vocsize(voc) > 0 || error("empty vocabulary")
     maxoccs = convert(Int32, maximum(voc.occs))
@@ -132,6 +155,13 @@ end
 @inline ndocs(model::VectorModel) = ndocs(model.voc)
 @inline token(model::VectorModel) = token(model.voc)
 
+"""
+    table(model::VectorModel, TableConstructor)
+
+Builds a Tables.jl-compatible table (e.g., a `DataFrame`) with one row per token,
+using `TableConstructor` (e.g. `DataFrame`) as the row-table constructor. Columns are
+`token`, `ndocs`, `occs`, and `weight`.
+"""
 function table(model::VectorModel, TableConstructor)
     TableConstructor(; token=token(model), ndocs=ndocs(model), occs=occs(model), weight=weight(model))
 end
@@ -148,6 +178,13 @@ function Base.getindex(model::VectorModel, tokenID::Integer)
     end
 end
 
+"""
+    filter_tokens(pred::Function, model::VectorModel)
+
+Returns a copy of `model` reduced to the tokens for which `pred(t)` is `true`, where
+`t` is a `(; id, occs, ndocs, weight, token)` named tuple (see also
+[`filter_tokens(pred, voc::Vocabulary)`](@ref filter_tokens)).
+"""
 function filter_tokens(pred::Function, model::VectorModel)
     voc = model.voc
     V = Vocabulary(voc.textconfig, trainsize(voc), numtokens(voc))
@@ -196,9 +233,12 @@ function vectorize_!(buff::TextSearchBuffer, model::VectorModel{G_,L_}, bow::BOW
 end
 
 """
-    vectorize!(buff::TextSearchBuffer, model::VectorModel{G_,L_}, bow::BOW; normalize=true, minweight=1e-9) where {G_,L_}
+    vectorize!(buff::TextSearchBuffer, model::VectorModel, text; normalize=true, minweight=1e-6)
 
-Computes a weighted vector using the given bag of words and the specified weighting scheme.
+Tokenizes `text`, computes its bag of words, and weights it using `model`'s local/global
+weighting scheme, storing the result in `buff.vec` (a [`SVEC`](@ref)); entries with a
+weight below `minweight` are dropped, and the result is L2-normalized unless
+`normalize=false`. Returns `buff`. See [`vectorize`](@ref) for a non-mutating version.
 """
 function vectorize!(buff::TextSearchBuffer, model::VectorModel, text; normalize=true, minweight=1e-6)
     empty!(buff)
@@ -206,6 +246,12 @@ function vectorize!(buff::TextSearchBuffer, model::VectorModel, text; normalize=
     vectorize_!(buff, model, buff.bow; normalize, minweight)
 end
 
+"""
+    vectorize(model::VectorModel, text; normalize=true, minweight=1e-6)
+
+Computes the weighted sparse vector ([`SVEC`](@ref)) representation of `text` under
+`model`. `text` can be a string or a list of strings (a multi-field document).
+"""
 function vectorize(model::VectorModel, text; normalize=true, minweight=1e-6)
     buff = take!(TEXT_SEARCH_CACHES)
     try
@@ -216,6 +262,13 @@ function vectorize(model::VectorModel, text; normalize=true, minweight=1e-6)
     end
 end
 
+"""
+    vectorize_corpus(model::VectorModel, corpus; normalize=true, minweight=1e-6, minbatch=0, verbose=true)
+
+Computes the [`vectorize`](@ref) representation of every document in `corpus`,
+processed in parallel across threads (`minbatch` controls the batch size, `0` picks an
+automatic value).
+"""
 function vectorize_corpus(model::VectorModel, corpus; normalize=true, minweight=1e-6, minbatch=0, verbose=true)
     corpus = collect(corpus)
     n = length(corpus)

--- a/src/vmodel.jl
+++ b/src/vmodel.jl
@@ -99,6 +99,19 @@ Build one with [`VectorModel(gw, lw, voc)`](@ref VectorModel).
 - `voc`: the underlying [`Vocabulary`](@ref).
 - `maxoccs`: maximum per-token occurrence count in `voc`, used by some local weightings.
 - `weight`: precomputed per-token global weight (`weight[tokenID]`).
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(IdfWeighting(), TfWeighting(), voc);
+
+julia> vectorize(model, "hello world")
+Dict{UInt32, Float32}(0x00000002 => 0.9293994, 0x00000001 => 0.36907572)
+```
 """
 mutable struct VectorModel{_G<:GlobalWeighting, _L<:LocalWeighting} <: TextModel
     global_weighting::_G
@@ -124,6 +137,19 @@ Creates a [`VectorModel`](@ref) for the given vocabulary `voc` using the local w
 `lw` (e.g. [`TfWeighting`](@ref)) and global weighting `gw` (e.g. [`IdfWeighting`](@ref)).
 The per-token global weight vector is computed from `voc` unless `weight` is given
 explicitly (e.g. when reusing weights computed elsewhere, such as [`EntropyWeighting`](@ref)).
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(IdfWeighting(), TfWeighting(), voc);
+
+julia> length(model.weight)
+6
+```
 """
 function VectorModel(gw::GlobalWeighting, lw::LocalWeighting, voc::Vocabulary; weight=nothing)
     vocsize(voc) > 0 || error("empty vocabulary")
@@ -161,6 +187,30 @@ end
 Builds a Tables.jl-compatible table (e.g., a `DataFrame`) with one row per token,
 using `TableConstructor` (e.g. `DataFrame`) as the row-table constructor. Columns are
 `token`, `ndocs`, `occs`, and `weight`.
+
+# Example
+
+```julia
+julia> using DataFrames
+
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(IdfWeighting(), TfWeighting(), voc);
+
+julia> table(model, DataFrame)
+6×4 DataFrame
+ Row │ token   ndocs  occs   weight
+     │ String  Int32  Int32  Float32
+─────┼────────────────────────────────
+   1 │ hello       2      2  0.485427
+   2 │ world       1      1  1.22239
+   3 │ there       1      1  1.22239
+   4 │ the         1      1  1.22239
+   5 │ cat         1      1  1.22239
+   6 │ sat         1      1  1.22239
+```
 """
 function table(model::VectorModel, TableConstructor)
     TableConstructor(; token=token(model), ndocs=ndocs(model), occs=occs(model), weight=weight(model))
@@ -184,6 +234,19 @@ end
 Returns a copy of `model` reduced to the tokens for which `pred(t)` is `true`, where
 `t` is a `(; id, occs, ndocs, weight, token)` named tuple (see also
 [`filter_tokens(pred, voc::Vocabulary)`](@ref filter_tokens)).
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(IdfWeighting(), TfWeighting(), voc);
+
+julia> vocsize(filter_tokens(t -> t.ndocs >= 2, model))
+1
+```
 """
 function filter_tokens(pred::Function, model::VectorModel)
     voc = model.voc
@@ -239,6 +302,23 @@ Tokenizes `text`, computes its bag of words, and weights it using `model`'s loca
 weighting scheme, storing the result in `buff.vec` (a [`SVEC`](@ref)); entries with a
 weight below `minweight` are dropped, and the result is L2-normalized unless
 `normalize=false`. Returns `buff`. See [`vectorize`](@ref) for a non-mutating version.
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(IdfWeighting(), TfWeighting(), voc);
+
+julia> buff = TextSearch.TextSearchBuffer();
+
+julia> TextSearch.vectorize!(buff, model, "hello world");
+
+julia> buff.vec
+Dict{UInt32, Float32}(0x00000002 => 0.9293994, 0x00000001 => 0.36907572)
+```
 """
 function vectorize!(buff::TextSearchBuffer, model::VectorModel, text; normalize=true, minweight=1e-6)
     empty!(buff)
@@ -251,6 +331,19 @@ end
 
 Computes the weighted sparse vector ([`SVEC`](@ref)) representation of `text` under
 `model`. `text` can be a string or a list of strings (a multi-field document).
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(IdfWeighting(), TfWeighting(), voc);
+
+julia> vectorize(model, "hello world")
+Dict{UInt32, Float32}(0x00000002 => 0.9293994, 0x00000001 => 0.36907572)
+```
 """
 function vectorize(model::VectorModel, text; normalize=true, minweight=1e-6)
     buff = take!(TEXT_SEARCH_CACHES)
@@ -268,6 +361,19 @@ end
 Computes the [`vectorize`](@ref) representation of every document in `corpus`,
 processed in parallel across threads (`minbatch` controls the batch size, `0` picks an
 automatic value).
+
+# Example
+
+```julia
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> model = VectorModel(IdfWeighting(), TfWeighting(), voc);
+
+julia> vectorize_corpus(model, corpus; verbose=false)[1]
+Dict{UInt32, Float32}(0x00000002 => 0.9293994, 0x00000001 => 0.36907572)
+```
 """
 function vectorize_corpus(model::VectorModel, corpus; normalize=true, minweight=1e-6, minbatch=0, verbose=true)
     corpus = collect(corpus)

--- a/src/voc.jl
+++ b/src/voc.jl
@@ -2,6 +2,23 @@
 
 export Vocabulary, occs, ndocs, token, vocsize, trainsize, numtokens, filter_tokens, tokenize_and_append!, merge_voc, update_voc!, vocabulary_from_thesaurus, token2id, encode, decode, table
 
+"""
+    Vocabulary
+
+Holds the token ⇄ id mapping produced while parsing a corpus, along with per-token
+occurrence and document-frequency counters. A `Vocabulary` is the entry point of the
+processing pipeline: it is built from a [`TextConfig`](@ref) and a corpus, and is
+later consumed by [`VectorModel`](@ref), [`BM25`](@ref), and [`bagofwords`](@ref).
+
+# Fields
+- `textconfig`: the [`TextConfig`](@ref) used to tokenize the corpus that produced this vocabulary.
+- `token`: `id -> token` string table.
+- `occs`: `id -> total number of occurrences` of the token across the corpus.
+- `ndocs`: `id -> number of documents` containing the token.
+- `token2id`: `token -> id` reverse mapping (`0` means "unknown token").
+- `trainsize`: number of documents used to build the vocabulary.
+- `numtokens`: total number of (non-unique) tokens seen while building the vocabulary.
+"""
 struct Vocabulary
     textconfig::TextConfig
     token::Vector{String}
@@ -22,20 +39,50 @@ function Base.show(io::IO, voc::Vocabulary; prefix="", indent="  ")
     show(io, voc.textconfig; prefix, indent)
 end
 
+"""
+    token2id(voc::Vocabulary, tok::AbstractString)::UInt32
+
+Looks up the id of `tok` in `voc`; returns `0` when `tok` is out of vocabulary.
+"""
 token2id(voc::Vocabulary, tok::AbstractString) = get(voc.token2id, tok, zero(UInt32))
 
+"""
+    decode(voc::Vocabulary, bow::Dict)
+
+Converts a `Dict` sparse vector indexed by token id (e.g., a [`BOW`](@ref)) into a
+`Dict` indexed by the corresponding token string.
+"""
 function decode(voc::Vocabulary, bow::Dict)
     Dict(voc.token[k] => v for (k, v) in bow)
 end
 
+"""
+    encode(voc::Vocabulary, bow::Dict)
+
+Converts a `Dict` sparse vector indexed by token string into a `Dict` indexed by
+token id, the inverse of [`decode`](@ref).
+"""
 function encode(voc::Vocabulary, bow::Dict)
     Dict(token2id(voc, k) => v for (k, v) in bow)
 end
 
+"""
+    table(voc::Vocabulary, TableConstructor)
+
+Builds a Tables.jl-compatible table (e.g., a `DataFrame`) with one row per token,
+using `TableConstructor` (e.g. `DataFrame`) as the row-table constructor. Columns are
+`token`, `ndocs`, and `occs`.
+"""
 function table(voc::Vocabulary, TableConstructor)
     TableConstructor(; voc.token, voc.ndocs, voc.occs)
 end
 
+"""
+    vocabulary_from_thesaurus(textconfig::TextConfig, tokens::AbstractVector)
+
+Creates a [`Vocabulary`](@ref) directly from a list of tokens (a thesaurus), instead
+of tokenizing a corpus; every token is registered with `occs=1` and `ndocs=1`.
+"""
 function vocabulary_from_thesaurus(textconfig::TextConfig, tokens::AbstractVector)
     n = length(tokens)
     voc = Vocabulary(textconfig, n)
@@ -49,7 +96,11 @@ end
 """
     Vocabulary(textconfig::TextConfig, trainsize::Int, numtokens::Int)
 
-Creates a `Vocabulary` struct
+Creates an empty `Vocabulary` (no tokens registered yet) preallocated with capacity
+hints based on `trainsize` (following Heaps' law). `trainsize` and `numtokens` may be
+`0` when unknown ahead of time; use [`push_token!`](@ref) or [`tokenize_and_append!`](@ref)
+to fill it, or use [`Vocabulary(textconfig, corpus)`](@ref Vocabulary) to build it directly
+from a corpus.
 """
 function Vocabulary(textconfig::TextConfig, trainsize::Int64, numtokens::Int64)
     # n == 0 means unknown
@@ -59,20 +110,24 @@ function Vocabulary(textconfig::TextConfig, trainsize::Int64, numtokens::Int64)
     sizehint!(voc.occs, vocsize)
     sizehint!(voc.ndocs, vocsize)
     sizehint!(voc.token2id, vocsize)
-    voc 
+    voc
 end
 
-"""
-    Vocabulary(textconfig, corpus; minbatch=0)
-
-Computes a vocabulary from a corpus using the TextConfig `textconfig`.
-"""
 function vocab_from_small_collection(textconfig::TextConfig, corpus::AbstractVector; minbatch::Int=0)
     voc = Vocabulary(textconfig, length(corpus), 0)
     tokenize_and_append!(voc, corpus; minbatch)
     voc
 end
 
+"""
+    Vocabulary(textconfig::TextConfig, corpus; minbatch=0, buffsize=2^16, verbose=true)
+
+Tokenizes `corpus` under `textconfig` and builds the resulting [`Vocabulary`](@ref).
+`corpus` can be any vector of documents (each document a string or a list of strings)
+or an iterable/generator of documents (useful for corpora too large to fit in memory);
+in the generator case, documents are consumed and tokenized in batches of `buffsize`.
+`minbatch` controls the batch size used for multithreading (`0` picks an automatic value).
+"""
 function Vocabulary(textconfig::TextConfig, corpusgenerator; minbatch::Int=0, buffsize::Int=2^16, verbose::Bool=true)
     if corpusgenerator isa AbstractVector && length(corpusgenerator) <= buffsize
         return vocab_from_small_collection(textconfig, corpusgenerator; minbatch)
@@ -161,18 +216,73 @@ end
 
 Base.length(voc::Vocabulary) = length(voc.occs)
 Base.eachindex(voc::Vocabulary) = eachindex(voc.occs)
+
+"""
+    vocsize(voc::Vocabulary)
+
+Number of unique tokens in `voc`.
+"""
 vocsize(voc::Vocabulary) = length(voc)
+
+"""
+    trainsize(voc::Vocabulary)
+
+Number of documents used to build `voc`.
+"""
 trainsize(voc::Vocabulary) = voc.trainsize[]
+
+"""
+    numtokens(voc::Vocabulary)
+
+Total number of (non-unique) tokens seen while building `voc`.
+"""
 numtokens(voc::Vocabulary) = voc.numtokens[]
+
+"""
+    avgdoclen(voc::Vocabulary)
+
+Average document length in tokens (`numtokens(voc) / trainsize(voc)`), used by [`BM25`](@ref).
+"""
 avgdoclen(voc::Vocabulary) = numtokens(voc) / trainsize(voc)
+
+"""
+    ndocs(voc::Vocabulary, tokenID::Integer)
+    ndocs(voc::Vocabulary)
+
+Number of documents containing the token `tokenID` (`0` is out-of-vocabulary and yields
+`0` instead of erroring), or the whole per-token vector when called without a `tokenID`.
+"""
 ndocs(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? zero(eltype(voc.ndocs)) : voc.ndocs[tokenID]
+
+"""
+    occs(voc::Vocabulary, tokenID::Integer)
+    occs(voc::Vocabulary)
+
+Total occurrences of the token `tokenID` across the corpus (`0` is out-of-vocabulary and
+yields `0` instead of erroring), or the whole per-token vector when called without a `tokenID`.
+"""
 occs(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? zero(eltype(voc.occs)) : voc.occs[tokenID]
+
+"""
+    token(voc::Vocabulary, tokenID::Integer)
+    token(voc::Vocabulary)
+
+The token string for `tokenID` (`0` is out-of-vocabulary and yields `""` instead of
+erroring), or the whole token vector when called without a `tokenID`.
+"""
 token(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? "" : voc.token[tokenID]
 
 @inline occs(voc::Vocabulary) = voc.occs
 @inline ndocs(voc::Vocabulary) = voc.ndocs
 @inline token(voc::Vocabulary) = voc.token
 
+"""
+    push_token!(voc::Vocabulary, token, occs::Integer, ndocs::Integer)
+    push_token!(voc::Vocabulary, token; occs::Integer=0, ndocs::Integer=0)
+
+Registers `token` in `voc` if not already present (assigning it a new id), or accumulates
+`occs`/`ndocs` into its existing entry otherwise. Returns the token's id.
+"""
 function push_token!(voc::Vocabulary, token, occs::Integer, ndocs::Integer)
     id = token2id(voc, token)
 

--- a/src/voc.jl
+++ b/src/voc.jl
@@ -18,6 +18,18 @@ later consumed by [`VectorModel`](@ref), [`BM25`](@ref), and [`bagofwords`](@ref
 - `token2id`: `token -> id` reverse mapping (`0` means "unknown token").
 - `trainsize`: number of documents used to build the vocabulary.
 - `numtokens`: total number of (non-unique) tokens seen while building the vocabulary.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> vocsize(voc)
+3
+
+julia> token2id(voc, "hello")
+0x00000001
+```
 """
 struct Vocabulary
     textconfig::TextConfig
@@ -43,6 +55,18 @@ end
     token2id(voc::Vocabulary, tok::AbstractString)::UInt32
 
 Looks up the id of `tok` in `voc`; returns `0` when `tok` is out of vocabulary.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> token2id(voc, "hello")
+0x00000001
+
+julia> token2id(voc, "unknown")
+0x00000000
+```
 """
 token2id(voc::Vocabulary, tok::AbstractString) = get(voc.token2id, tok, zero(UInt32))
 
@@ -51,6 +75,15 @@ token2id(voc::Vocabulary, tok::AbstractString) = get(voc.token2id, tok, zero(UIn
 
 Converts a `Dict` sparse vector indexed by token id (e.g., a [`BOW`](@ref)) into a
 `Dict` indexed by the corresponding token string.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> decode(voc, bagofwords(voc, "hello hello"))
+Dict{String, Int32}("hello" => 2)
+```
 """
 function decode(voc::Vocabulary, bow::Dict)
     Dict(voc.token[k] => v for (k, v) in bow)
@@ -61,6 +94,15 @@ end
 
 Converts a `Dict` sparse vector indexed by token string into a `Dict` indexed by
 token id, the inverse of [`decode`](@ref).
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world"]; verbose=false);
+
+julia> encode(voc, Dict("hello" => 2))
+Dict{UInt32, Int64}(0x00000001 => 2)
+```
 """
 function encode(voc::Vocabulary, bow::Dict)
     Dict(token2id(voc, k) => v for (k, v) in bow)
@@ -72,6 +114,28 @@ end
 Builds a Tables.jl-compatible table (e.g., a `DataFrame`) with one row per token,
 using `TableConstructor` (e.g. `DataFrame`) as the row-table constructor. Columns are
 `token`, `ndocs`, and `occs`.
+
+# Example
+
+```julia
+julia> using DataFrames
+
+julia> corpus = ["hello world", "hello there", "the cat sat"];
+
+julia> voc = Vocabulary(TextConfig(), corpus; verbose=false);
+
+julia> table(voc, DataFrame)
+6×3 DataFrame
+ Row │ token   ndocs  occs
+     │ String  Int32  Int32
+─────┼──────────────────────
+   1 │ hello       2      2
+   2 │ world       1      1
+   3 │ there       1      1
+   4 │ the         1      1
+   5 │ cat         1      1
+   6 │ sat         1      1
+```
 """
 function table(voc::Vocabulary, TableConstructor)
     TableConstructor(; voc.token, voc.ndocs, voc.occs)
@@ -82,10 +146,22 @@ end
 
 Creates a [`Vocabulary`](@ref) directly from a list of tokens (a thesaurus), instead
 of tokenizing a corpus; every token is registered with `occs=1` and `ndocs=1`.
+
+# Example
+
+```julia
+julia> voc = vocabulary_from_thesaurus(TextConfig(), ["cat", "dog", "bird"]);
+
+julia> vocsize(voc)
+3
+
+julia> token2id(voc, "cat")
+0x00000001
+```
 """
 function vocabulary_from_thesaurus(textconfig::TextConfig, tokens::AbstractVector)
     n = length(tokens)
-    voc = Vocabulary(textconfig, n)
+    voc = Vocabulary(textconfig, n, n)
     for t in tokens
         push_token!(voc, t, 1, 1)
     end
@@ -101,6 +177,18 @@ hints based on `trainsize` (following Heaps' law). `trainsize` and `numtokens` m
 `0` when unknown ahead of time; use [`push_token!`](@ref) or [`tokenize_and_append!`](@ref)
 to fill it, or use [`Vocabulary(textconfig, corpus)`](@ref Vocabulary) to build it directly
 from a corpus.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), 0, 0);
+
+julia> TextSearch.push_token!(voc, "cat"; occs=1, ndocs=1)
+0x00000001
+
+julia> vocsize(voc)
+1
+```
 """
 function Vocabulary(textconfig::TextConfig, trainsize::Int64, numtokens::Int64)
     # n == 0 means unknown
@@ -127,6 +215,15 @@ Tokenizes `corpus` under `textconfig` and builds the resulting [`Vocabulary`](@r
 or an iterable/generator of documents (useful for corpora too large to fit in memory);
 in the generator case, documents are consumed and tokenized in batches of `buffsize`.
 `minbatch` controls the batch size used for multithreading (`0` picks an automatic value).
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> vocsize(voc), trainsize(voc)
+(3, 2)
+```
 """
 function Vocabulary(textconfig::TextConfig, corpusgenerator; minbatch::Int=0, buffsize::Int=2^16, verbose::Bool=true)
     if corpusgenerator isa AbstractVector && length(corpusgenerator) <= buffsize
@@ -176,6 +273,17 @@ end
     tokenize_and_append!(voc::Vocabulary, corpus; minbatch=0)
 
 Parse each document in the given corpus and appends each token to the vocabulary.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), 0, 0);
+
+julia> tokenize_and_append!(voc, ["hello world", "hello there"]);
+
+julia> vocsize(voc)
+3
+```
 """
 function tokenize_and_append!(voc::Vocabulary, corpus; minbatch=0)
     l = Threads.SpinLock()
@@ -251,6 +359,15 @@ avgdoclen(voc::Vocabulary) = numtokens(voc) / trainsize(voc)
 
 Number of documents containing the token `tokenID` (`0` is out-of-vocabulary and yields
 `0` instead of erroring), or the whole per-token vector when called without a `tokenID`.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> ndocs(voc, token2id(voc, "hello"))
+2
+```
 """
 ndocs(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? zero(eltype(voc.ndocs)) : voc.ndocs[tokenID]
 
@@ -260,6 +377,15 @@ ndocs(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? zero(eltype(voc.ndocs)
 
 Total occurrences of the token `tokenID` across the corpus (`0` is out-of-vocabulary and
 yields `0` instead of erroring), or the whole per-token vector when called without a `tokenID`.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> occs(voc, token2id(voc, "hello"))
+2
+```
 """
 occs(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? zero(eltype(voc.occs)) : voc.occs[tokenID]
 
@@ -269,6 +395,15 @@ occs(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? zero(eltype(voc.occs)) 
 
 The token string for `tokenID` (`0` is out-of-vocabulary and yields `""` instead of
 erroring), or the whole token vector when called without a `tokenID`.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), ["hello world", "hello there"]; verbose=false);
+
+julia> token(voc, token2id(voc, "hello"))
+"hello"
+```
 """
 token(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? "" : voc.token[tokenID]
 
@@ -282,6 +417,15 @@ token(voc::Vocabulary, tokenID::Integer) = tokenID == 0 ? "" : voc.token[tokenID
 
 Registers `token` in `voc` if not already present (assigning it a new id), or accumulates
 `occs`/`ndocs` into its existing entry otherwise. Returns the token's id.
+
+# Example
+
+```julia
+julia> voc = Vocabulary(TextConfig(), 0, 0);
+
+julia> TextSearch.push_token!(voc, "cat"; occs=1, ndocs=1)
+0x00000001
+```
 """
 function push_token!(voc::Vocabulary, token, occs::Integer, ndocs::Integer)
     id = token2id(voc, token)


### PR DESCRIPTION
## Summary
- Add `AGENTIC.md`: an overview of the package's processing pipeline, a file-by-file map of `src/`, dev/test/docs commands, and repo-specific conventions, to help AI coding agents work in this repo.
- Add or fix docstrings for the main structs and functions across the package: `Vocabulary`, `TokenizedText`, `VectorModel` and its weighting schemes, `BM25`/`BM25InvertedFile`, and their supporting functions (`tokenize`, `bagofwords`, `vectorize`, `search`, `normalize_text`, etc). Several existing docstrings were stale or copy-pasted from the wrong method (e.g. `BM25InvertedFile`'s constructor documented a nonexistent `db` parameter, `EntropyWeighting` documented a kwarg constructor that doesn't exist, the `search` docstring had a malformed/unclosed signature).
- Add a verified `# Example` section to the docstrings of the main structs/functions. Each example was executed against Julia 1.10 before being committed (not `jldoctest`-checked, but hand-verified), covering the tokenization → vocabulary → bag-of-words → vector model / BM25 pipeline end-to-end.

## Bug fixes found while writing the examples
Writing an honest example for a couple of exported functions surfaced real bugs with no test coverage:
- `vocabulary_from_thesaurus` called the wrong `Vocabulary` constructor (it matched the corpus-iterator method instead of the `(trainsize, numtokens)` one), so it always errored.
- `BM25InvertedFile`'s generic `SimilaritySearch.push_item!` method had three independent bugs: the `docID::UInt32` keyword default was never converted from `Int`, `sparseiterator` was called unqualified instead of `InvertedFiles.sparseiterator`, and it referenced a `db` field that `BM25InvertedFile` has never had. All three combined to make `push_item!` completely non-functional.

## Test plan
- [x] `Pkg.instantiate()` + `Pkg.test()` pass (Julia 1.10, via juliaup)
- [x] `julia --project=docs docs/make.jl` builds cleanly with no "Cannot resolve @ref" warnings
- [x] Manually verified every added example against a real Julia 1.10 session


---
_Generated by [Claude Code](https://claude.ai/code/session_01WxoX5vcBRtLL2qBjvizNhc)_